### PR TITLE
Fix bug in `toggle.iconEnabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to the "setting-toggle" extension will be documented in this file.
 
+## [1.6.1] (08 May 2023)
+- Fix bug in `"toggle.iconEnabled"`
+
 ## [1.6.0] (03 March 2022)
 - Enable text in status bar to be customized.
 - Use eye icon to show if feature is on or off.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "setting-toggle",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Setting Toggle",
   "description": "Toggle VS Code setting between two states.",
   "icon": "images/T-icon.png",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publisher": "Ho-Wan",
   "author": {
     "name": "Ho-Wan To",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ const SettingState2: string = "toggle.settingState2";
 const PrimarySettingText: string = "toggle.primarySettingText";
 const SettingState1Text: string = "toggle.settingState1Text";
 const SettingState2Text: string = "toggle.settingState2Text";
+const IconEnabled: string = "toggle.iconEnabled";
 const State1Default: string = "state1";
 const State2Default: string = "state2";
 const StateOn: string = "$(eye)";
@@ -89,7 +90,7 @@ function showInStatusBar() {
   for (const [, setting] of Object.entries(Setting)) {
     const settingTitle: string = config.get(setting.title);
     // shows in the status bar if config is enabled and setting has been found
-    if (config.get(setting.statusBar.config) && settingTitle) {
+    if (config.get(setting.statusBar.config) && settingTitle && config.get(IconEnabled)) {
       // icon at the status bar for boolean status
       const state = config.get(settingTitle);
       if (state !== undefined && typeof state === "boolean") {


### PR DESCRIPTION
The advertised setting `toggle.iconEnabled` isn't hooked up to any actual functionality. This fixes that.